### PR TITLE
Stop using deprecated versions of dependencies

### DIFF
--- a/yesod-auth-fb.cabal
+++ b/yesod-auth-fb.cabal
@@ -44,9 +44,7 @@ Library
                  , lifted-base  >= 0.1     && < 0.3
                  , yesod-core   >= 1.2     && < 1.5
                  , yesod-auth   >= 1.3     && < 1.5
-                 , hamlet
-                 , shakespeare
-                 , shakespeare-js >= 1.0.2
+                 , shakespeare  >= 2.0
                  , wai
                  , http-conduit >= 1.9
                  , text         >= 0.7     && < 1.2


### PR DESCRIPTION
Hey @meteficha. Your call on whether to merge this. It requires a newer version of shakespeare (which is compatible with Yesod 1.2), and thereby gets rid of a dependency on two deprecated packages.
