### PR TITLE
get,delete,setUserAccessToken should be more general

### DIFF
--- a/src/Yesod/Auth/Facebook/ServerSide.hs
+++ b/src/Yesod/Auth/Facebook/ServerSide.hs
@@ -129,8 +129,8 @@ createCreds (FB.UserAccessToken (FB.Id userId) _ _) = Creds "fb" id_ []
 -- | Set the Facebook's user access token on the user's session.
 -- Usually you don't need to call this function, but it may
 -- become handy together with 'FB.extendUserAccessToken'.
-setUserAccessToken :: FB.UserAccessToken
-                   -> HandlerT site IO ()
+setUserAccessToken :: MonadHandler m => FB.UserAccessToken
+                   -> m ()
 setUserAccessToken (FB.UserAccessToken (FB.Id userId) data_ exptime) = do
   setSession "_FBID" userId
   setSession "_FBAT" data_
@@ -142,7 +142,7 @@ setUserAccessToken (FB.UserAccessToken (FB.Id userId) data_ exptime) = do
 -- is not logged in via @yesod-auth-fb@).  Note that the returned
 -- access token may have expired, we recommend using
 -- 'FB.hasExpired' and 'FB.isValid'.
-getUserAccessToken :: HandlerT site IO (Maybe FB.UserAccessToken)
+getUserAccessToken :: MonadHandler m => m (Maybe FB.UserAccessToken)
 getUserAccessToken = runMaybeT $ do
   userId  <- MaybeT $ lookupSession "_FBID"
   data_   <- MaybeT $ lookupSession "_FBAT"
@@ -152,7 +152,7 @@ getUserAccessToken = runMaybeT $ do
 
 -- | Delete Facebook's user access token from the session.  /Do/
 -- /not use/ this function unless you know what you're doing.
-deleteUserAccessToken :: HandlerT site IO ()
+deleteUserAccessToken :: MonadHandler m => m ()
 deleteUserAccessToken = do
   deleteSession "_FBID"
   deleteSession "_FBAT"


### PR DESCRIPTION
Would close #14 

Tested with yesod-core v 1.4.12, but verified visually that it should work with 1.2.

http://hackage.haskell.org/package/yesod-core-1.2.0/docs/Yesod-Core-Handler.html#v:deleteSession
http://hackage.haskell.org/package/yesod-core-1.2.0/docs/Yesod-Core-Handler.html#v:getSession
http://hackage.haskell.org/package/yesod-core-1.2.0/docs/Yesod-Core-Handler.html#v:lookupSession
http://hackage.haskell.org/package/yesod-core-1.2.0/docs/Yesod-Core-Handler.html#v:setSession
http://hackage.haskell.org/package/yesod-core-1.2.0/docs/Yesod-Core-Handler.html#v:clearSession

all have general enough types for this to work.
