### PR TITLE
Bump minor version numbers for time and transformers to match version…

### DIFF
--- a/yesod-auth-fb.cabal
+++ b/yesod-auth-fb.cabal
@@ -48,13 +48,13 @@ Library
                  , wai
                  , http-conduit >= 1.9
                  , text         >= 0.7     && < 1.3
-                 , transformers >= 0.1.3   && < 0.5
+                 , transformers >= 0.1.3   && < 0.6
                  , yesod-fb     == 0.3.*
                  , fb           >= 0.14    && < 1.1
                  , conduit      >= 1.0     && < 1.3
                  , bytestring   >= 0.9     && < 0.11
                  , aeson        >= 0.6
-                 , time         >= 1.0     && < 1.6
+                 , time         >= 1.0     && < 1.7
 
   Exposed-modules: Yesod.Auth.Facebook
                  , Yesod.Auth.Facebook.ClientSide


### PR DESCRIPTION
… numbers changes in stackage lts-7.0

Unless I'm incorrect, it's safe to bump the version numbers up for [time](https://www.stackage.org/lts-7.0/package/time-1.6.0.1#changes) and for [transformers](https://www.stackage.org/lts-7.0/package/transformers-0.5.2.0#changes) which would make yesod-auth-fb compatible with the [version changes](https://www.stackage.org/diff/lts-6.17/lts-7.0) in lts-7.0

One thing to note is that in transformers the module `Control.Monad.Trans.Error` has been deprecated and `Control.Monad.Trans.Except` is recommended instead. This only seems to affect the client side code of yesod-auth-fb and it's been deprecated since version 0.4.0.0 so it's not a new deprecation added in transformer > 0.5. 
